### PR TITLE
allow anyone to read usernames

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,5 +8,9 @@ service cloud.firestore {
       // Allow all logged-in users to read all other parts of the database
       allow read: if request.auth.uid != null;
     }
+    match /usernames/{document=**} {
+      // Allow all users to read usernames
+      allow read;
+    }
   }
 }


### PR DESCRIPTION
The Android team is checking if the username is taken on the setup profile screen in addition to the registration screen to decrease the chance that the user has to go back to the setup profile screen from the registration screen when the username is already taken. We do this by getting the firestore document for the username the user enters and checking if it exists already, so we need to allow read access to the username documents for people that aren't logged in.
I think this solution is simpler and more efficient than the lease solution we discussed [here](https://michiganhackers.slack.com/archives/CN9GYUF60/p1574298112000700).