### PR TITLE
changed user's arrays to collections, + gamesWon

### DIFF
--- a/functions/__tests__/addUser.test.js
+++ b/functions/__tests__/addUser.test.js
@@ -36,7 +36,8 @@ test("addUser creates a user with given display name & username (lowercased) and
         username: username.toLowerCase(),
         id: uid,
         kills: 0,
-        longestLifeSeconds: 0
+        longestLifeSeconds: 0,
+        gamesWon: 0
     };
     const user = await usersRef.doc("testUserID").get();
     expect(user.data()).toEqual(userExpected);

--- a/functions/__tests__/startGame.test.js
+++ b/functions/__tests__/startGame.test.js
@@ -72,12 +72,10 @@ test("game started w/ 4 players has valid default values", async () => {
         expect(sniper.get("target")).toBe(player.get("uid"));
     });
 
-    const playerUserPromises = await userIDs.map(uid => usersRef.doc(uid).get());
-    const playerUsers = await Promise.all(playerUserPromises);
-    playerUsers.forEach(user => {
-        const currentGames = user.get("currentGames");
+    const userCurrentGames = await Promise.all(userIDs.map(id => usersRef.doc(id).collection("currentGames").listDocuments()));
+    userCurrentGames.forEach(currentGames => {
         expect(currentGames.length).toBe(1);
-        expect(currentGames).toContain(gameID);
+        expect(currentGames[0].id).toBe(gameID);
     });
 });
 
@@ -133,10 +131,11 @@ test("make sure starting multiple games show up in currentGames", async () => {
     const context = { auth: { uid: ownerUID } };
     await Promise.all(gameIDs.map(id => startGameWrapped({ gameID: id }, context)))
 
-    const users = await Promise.all(userIDs.map(id => usersRef.doc(id).get()));
-    users.forEach(user => {
+    const userCurrentGames = await Promise.all(userIDs.map(id => usersRef.doc(id).collection("currentGames").listDocuments()));
+    userCurrentGames.forEach(currentGames => {
+        const currentGameIds = currentGames.map(ref => ref.id);
         gameIDs.forEach(gameID => {
-            expect(user.get("currentGames")).toContain(gameID);
+            expect(currentGameIds).toContain(gameID);
         });
     });
 });

--- a/functions/addUser.js
+++ b/functions/addUser.js
@@ -46,7 +46,8 @@ module.exports = functions.https.onCall(async (data, context) => {
         username: usernameLower,
         id: uid,
         kills: 0,
-        longestLifeSeconds: 0
+        longestLifeSeconds: 0,
+        gamesWon: 0
       });
       t.create(usernamesRef.doc(usernameLower), { username: usernameLower, uid: uid });
 

--- a/functions/startGame.js
+++ b/functions/startGame.js
@@ -62,7 +62,8 @@ module.exports = functions.https.onCall(async (data, context) => {
         sniper: i === 0 ? playerRefs[playerRefs.length - 1].id : playerRefs[i - 1].id,
         target: i === playerRefs.length - 1 ? playerRefs[0].id : playerRefs[i + 1].id
       });
-      t.update(usersRef.doc(playerRef.id), { currentGames: admin.firestore.FieldValue.arrayUnion(gameID) })
+      const currentGamesRef = usersRef.doc(playerRef.id).collection("currentGames");
+      t.create(currentGamesRef.doc(gameID), {gameID: gameID});
     });
 
     t.update(gameRef, {


### PR DESCRIPTION
I didn't plan on continuing to work on this, but I just remembered that I meant to change the currentGames and completedGames for the users from arrays to collections because that's what we had planned on. This PR does that as well as adds a gamesWon field to the user so we can display that in the profile stats screen.
One thing to note is that using collections instead of arrays in this case could make it harder to calculate win % because you can't as easily determine the number of documents (that exist) in the completedGames collection as you can just take the length of an array. You can decide which way you want to do it and if you want to accept this PR. Just note that the Android app currently assumes they are collections, so if you decide to do arrays then you should tell the Android team (it's just a small change).